### PR TITLE
Combined dependencies PR

### DIFF
--- a/action-build-artifacts-download/action.yaml
+++ b/action-build-artifacts-download/action.yaml
@@ -22,7 +22,7 @@ runs:
       id: artifacts-directory
       run: echo "artifacts-directory=$(mktemp -d)" >> $GITHUB_OUTPUT
 
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
+    - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # pin@v3
       with:
         path: "${{ steps.downloads-directory.outputs.downloads-directory }}"
 

--- a/action-build-artifacts-upload/action.yaml
+++ b/action-build-artifacts-upload/action.yaml
@@ -20,7 +20,7 @@ runs:
       with:
         name: ${{ inputs.description }}
 
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
+    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # pin@v3
       with:
         name: build-artifacts-${{ steps.description.outputs.name }}
         path: ${{ inputs.build-files }}

--- a/action-upload-test-results/action.yaml
+++ b/action-upload-test-results/action.yaml
@@ -22,7 +22,7 @@ runs:
       with:
         name: ${{ inputs.component-name }}
 
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
+    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # pin@v3
       with:
         name: >
           test-reports-type-${{ inputs.type }}${{ inputs.os-name != '' && '-on-' || '' }}${{

--- a/docker-build-artifact/action.yaml
+++ b/docker-build-artifact/action.yaml
@@ -33,7 +33,7 @@ runs:
     - uses: aps831/gh-actions/set-up-docker@master
 
     # build
-    - uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # pin@v3
+    - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # pin@v3
       with:
         context: ${{ inputs.docker-context }}
         file: ${{ inputs.dockerfile }}
@@ -46,7 +46,7 @@ runs:
         target: ${{ inputs.stage-build }}
 
     # output
-    - uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # pin@v3
+    - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # pin@v3
       with:
         context: ${{ inputs.docker-context }}
         file: ${{ inputs.dockerfile }}
@@ -58,7 +58,7 @@ runs:
         target: ${{ inputs.stage-output }}
 
     # status
-    - uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # pin@v3
+    - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # pin@v3
       with:
         context: ${{ inputs.docker-context }}
         file: ${{ inputs.dockerfile }}

--- a/docker-build-image/action.yaml
+++ b/docker-build-image/action.yaml
@@ -49,7 +49,7 @@ runs:
       id: hash
 
     # build
-    - uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # pin@v3
+    - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # pin@v3
       with:
         context: ${{ inputs.docker-context }}
         file: ${{ inputs.dockerfile }}
@@ -66,7 +66,7 @@ runs:
       shell: bash
       run: rm -rf ${{ inputs.output-directory }}
 
-    - uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # pin@v3
+    - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # pin@v3
       with:
         context: ${{ inputs.docker-context }}
         file: ${{ inputs.dockerfile }}
@@ -78,7 +78,7 @@ runs:
         target: ${{ inputs.stage-output }}
 
     # status
-    - uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # pin@v3
+    - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # pin@v3
       with:
         context: ${{ inputs.docker-context }}
         file: ${{ inputs.dockerfile }}
@@ -94,7 +94,7 @@ runs:
       shell: bash
 
     # image
-    - uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # pin@v3
+    - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # pin@v3
       with:
         context: ${{ inputs.docker-context }}
         file: ${{ inputs.dockerfile }}

--- a/git-checkout/action.yaml
+++ b/git-checkout/action.yaml
@@ -26,7 +26,7 @@ runs:
         git pull --ff-only
 
     - if: ${{ steps.check.outputs.isrepo == 'false' }}
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       with:
         ref: ${{ inputs.branch }}
         fetch-depth: 0

--- a/install-native-image-windows-dependencies/action.yaml
+++ b/install-native-image-windows-dependencies/action.yaml
@@ -8,4 +8,4 @@ runs:
       uses: microsoft/setup-msbuild@1ff57057b5cfdc39105cd07a01d78e9b0ea0c14c # pin@v1.3.1
 
     - name: Visual Studio shell
-      uses: egor-tensin/vs-shell@6d88c01ad4b6b33190d261b45e241e462545652b # pin@v1
+      uses: egor-tensin/vs-shell@9a932a62d05192eae18ca370155cf877eecc2202 # pin@v2.1

--- a/install-native-image-windows-dependencies/action.yaml
+++ b/install-native-image-windows-dependencies/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@c26a08ba26249b81327e26f6ef381897b6a8754d # pin@v1.0.2
+      uses: microsoft/setup-msbuild@1ff57057b5cfdc39105cd07a01d78e9b0ea0c14c # pin@v1.3.1
 
     - name: Visual Studio shell
       uses: egor-tensin/vs-shell@6d88c01ad4b6b33190d261b45e241e462545652b # pin@v1

--- a/set-up-docker/action.yaml
+++ b/set-up-docker/action.yaml
@@ -4,4 +4,4 @@ description: Set up Docker
 runs:
   using: "composite"
   steps:
-    - uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # pin@v2
+    - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # pin@v2

--- a/set-up-jdk/action.yaml
+++ b/set-up-jdk/action.yaml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # pin@v3
+    - uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # pin@v3
       with:
         java-version: ${{ inputs.java-version }}
         distribution: "adopt"

--- a/set-up-nodejs/action.yaml
+++ b/set-up-nodejs/action.yaml
@@ -4,4 +4,4 @@ description: Set up Nodejs
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3.5.0
+    - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # pin@v4.0.1

--- a/set-up-terraform/action.yaml
+++ b/set-up-terraform/action.yaml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: mkdir --parents ${{ steps.plugin.outputs.plugin-cache-directory }}
 
-    - uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+    - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # pin@v3.3.2
       with:
         path: ${{ steps.plugin.outputs.plugin-cache-directory }}
         key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}

--- a/set-up-terraform/action.yaml
+++ b/set-up-terraform/action.yaml
@@ -14,7 +14,7 @@ runs:
       run: |
         echo "plugin-cache-directory=${{ github.workspace }}/.terraform.d/plugin-cache" >> $GITHUB_OUTPUT
 
-    - uses: hashicorp/setup-terraform@bbe167fbdaa1a3bd046bdd70eba9dd3dddcca99c # pin@v2.0.2
+    - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # pin@v3.0.0
       with:
         terraform_version: ${{ inputs.terraform-version }}
         terraform_wrapper: false


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* chore(deps): bump hashicorp/setup-terraform from 2.0.2 to 3.0.0 in /set-up-terraform (#15) @app/dependabot
* chore(deps): bump actions/setup-java from 3.13.0 to 4.0.0 in /set-up-jdk (#14) @app/dependabot
* chore(deps): bump actions/cache from 3.0.11 to 3.3.2 in /set-up-terraform (#12) @app/dependabot
* chore(deps): bump actions/setup-node from 3.5.0 to 4.0.1 in /set-up-nodejs (#13) @app/dependabot
* chore(deps): bump microsoft/setup-msbuild from 1.0.2 to 1.3.1 in /install-native-image-windows-dependencies (#11) @app/dependabot
* chore(deps): bump docker/setup-buildx-action from 2.10.0 to 3.0.0 in /set-up-docker (#10) @app/dependabot
* chore(deps): bump docker/build-push-action from 3.3.1 to 5.1.0 in /docker-build-image (#9) @app/dependabot
* chore(deps): bump egor-tensin/vs-shell from 1 to 2 in /install-native-image-windows-dependencies (#8) @app/dependabot
* chore(deps): bump actions/checkout from 3.1.0 to 4.1.1 in /git-checkout (#7) @app/dependabot
* chore(deps): bump actions/download-artifact from 3.0.2 to 4.1.0 in /action-build-artifacts-download (#4) @app/dependabot
* chore(deps): bump actions/upload-artifact from 3.1.3 to 4.0.0 in /action-upload-test-results (#5) @app/dependabot
* chore(deps): bump docker/build-push-action from 3.3.1 to 5.1.0 in /docker-build-artifact (#6) @app/dependabot
* chore(deps): bump actions/upload-artifact from 3.1.3 to 4.0.0 in /action-build-artifacts-upload (#3) @app/dependabot
